### PR TITLE
Add Keil uVision autogenerated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# KeiluVision auto-generated files
+*/Objects/
+*/DebugConfig/
+*/Listings/
+
 # Prerequisites
 *.d
 


### PR DESCRIPTION
We don't want the files that keil creates. We should have in mind that the project also generates the  _project.name_ files.
I think there are two options:

- Remove them manually before uploading
- Each of us adds the extension to the gitignore in this branch.
